### PR TITLE
add pip install pymodbus==2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,5 +63,7 @@ RUN apt-get update && \
     echo "alias cs='cd ~/catkin_ws/src'" >> ~/.bashrc && \
     echo "alias cw='cd ~/catkin_ws'" >> ~/.bashrc
 
-RUN python3 -m pip install --user --upgrade --no-cache-dir --no-warn-script-location pip && \
+RUN python3 -m pip install --user --upgrade --no-cache-dir --no-warn-script-location \
+    pip \
+    pymodbus==2.5.3 && \
     chown -R $USER:$USER $HOME/.local/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # igvc2024_docker
-This is a project for igvc2024.
+This is a project for IGVC2024.


### PR DESCRIPTION
pymodbus==2.5.3のインストールを記述した。

・背景
去年では、新しいコンテナを作ったときに毎回pymodbus==2.5.3をインストールしていたため。