### PR TITLE
fix environment variable bug in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,6 @@ RUN apt-get update && \
     sed -i "s/192.168.1.5/192.168.3.1/g" /home/ubuntu/livox_ws/src/livox_ros_driver2/config/MID360_config.json && \
     # Update lidar IP address
     sed -i "s/192.168.1.12/192.168.3.201/g" /home/ubuntu/livox_ws/src/livox_ros_driver2/config/MID360_config.json && \
-    echo "source /home/ubuntu/livox_ws/devel/setup.bash" >> ~/.bashrc && \
     echo "alias lsl='cd ~/livox_ws/src/livox_ros_driver2'" >> ~/.bashrc && \
     echo "alias lw='cd ~/livox_ws'" >> ~/.bashrc
 


### PR DESCRIPTION
`~/.bashrc`に`source ~/livox_ws/devel/setup.bash`を良かれと思って書き込んだのですが、余計なことだったらしく、ビルド時に環境変数の取り合いが起こりました。どうやら`~/livox_ws/devel/setup.bash`は最初のビルド時にやるだけで良さそうなので、Dockerfileから取り除きました。