### PR TITLE
Feature/livox

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,0 @@
-docker build -t igvc2024:latest .

--- a/livox_build.sh
+++ b/livox_build.sh
@@ -1,0 +1,1 @@
+docker build -t igvc2024/livox:latest .

--- a/livox_run.sh
+++ b/livox_run.sh
@@ -1,0 +1,20 @@
+docker run \
+	-e HOME=/home/ubuntu \
+	-e SHELL=/bin/bash \
+	--shm-size=512m \
+    --privileged -it \
+    --net=host \
+	--entrypoint '/startup.sh' \
+	--device /dev/ZLAC8015D:/dev/ZLAC8015D:mwr \
+	--device /dev/sensors/hokuyo_urg:/dev/sensors/hokuyo_urg:mwr \
+	--device /dev/sensors/imu:/dev/sensors/imu:mwr \
+	--device /dev/sensors/insta360_air:/dev/sensors/insta360_air:mwr \
+	--device /dev/input/js0:/dev/input/js0:mwr \
+	--device /dev/ttyACM0:/dev/ttyACM0:mwr \
+	--device /dev/ttyACM1:/dev/ttyACM1:mwr \
+	--device /dev/ttyACM2:/dev/ttyACM2:mwr \
+	--device /dev/E-Stop:/dev/E-Stop:mwr \
+	--device /dev/sensors/LED:/dev/sensors/LED:mwr \
+	igvc2024/livox
+	
+	#-e RESOLUTION=1920x1080

--- a/livox_runLite.sh
+++ b/livox_runLite.sh
@@ -1,0 +1,10 @@
+docker run \
+    -e HOME=/home/ubuntu \
+    -e SHELL=/bin/bash \
+    --shm-size=512m \
+    --privileged -it \
+    --net=host \
+    --entrypoint '/startup.sh'\
+    igvc2024/livox
+    
+    #-e RESOLUTION=1920x1080 \

--- a/velodyne.sh
+++ b/velodyne.sh
@@ -1,0 +1,8 @@
+while true
+do
+    sudo ifconfig enx207bd23333fa 192.168.3.1
+    sudo route add -host 192.168.3.11 gw 192.168.3.1 enx207bd2333fa
+    sudo route add -host 192.168.3.201 gw 192.168.3.1 enx207bd2333fa
+
+    sleep 2
+done

--- a/velodyne_build.sh
+++ b/velodyne_build.sh
@@ -1,0 +1,1 @@
+docker build -t igvc2024/velodyne:latest .

--- a/velodyne_run.sh
+++ b/velodyne_run.sh
@@ -18,6 +18,7 @@ docker run \
 	--device /dev/ttyACM2:/dev/ttyACM2:mwr \
 	--device /dev/E-Stop:/dev/E-Stop:mwr \
 	--device /dev/sensors/LED:/dev/sensors/LED:mwr \
-	igvc2024
+	igvc2024/velodyne
 	
 	#-e RESOLUTION=1920x1080
+	

--- a/velodyne_run.sh
+++ b/velodyne_run.sh
@@ -21,4 +21,3 @@ docker run \
 	igvc2024/velodyne
 	
 	#-e RESOLUTION=1920x1080
-	

--- a/velodyne_runLite.sh
+++ b/velodyne_runLite.sh
@@ -8,6 +8,6 @@ docker run \
     -e SHELL=/bin/bash \
     --shm-size=512m \
     --entrypoint '/startup.sh'\
-    igvc2024
+    igvc2024/velodyne
     
     #-e RESOLUTION=1920x1080 \


### PR DESCRIPTION
livoxのmid-360を使うためにシェルスクリプトを書きました。
元々使っていたシェルスクリプトはvelodyne用とすることで、velodyneを使うときとlivoxを使うときで使い分けができるようにしました。